### PR TITLE
Logging a non existant error in WindowsDeviceBase class

### DIFF
--- a/src/Device.Net/Windows/WindowsDeviceBase.cs
+++ b/src/Device.Net/Windows/WindowsDeviceBase.cs
@@ -48,6 +48,10 @@ namespace Device.Net.Windows
         {
             if (isSuccess) return;
             var errorCode = Marshal.GetLastWin32Error();
+
+            //TODO: Loggin
+            if (errorCode == 0) return;
+
             throw new Exception($"{message}. Error code: {errorCode}");
         }
         #endregion


### PR DESCRIPTION
This is a change in the WindowsDeviceBase class to solve an error problem that occurred with connecting a HID Generic USB Joystick.