### PR TITLE
Fix CS0121 Compiling Error.

### DIFF
--- a/src/Usb.Net/Windows/WindowsUsbDevice.cs
+++ b/src/Usb.Net/Windows/WindowsUsbDevice.cs
@@ -90,7 +90,7 @@ namespace Usb.Net.Windows
         {
             if (disposed) throw new Exception(DeviceDisposedErrorMessage);
 
-            await Task.Run(Initialize);
+            await Task.Run(() => Initialize());
         }
 
         public override async Task<byte[]> ReadAsync()


### PR DESCRIPTION
It may cause by the new C# 7.3 compiler.I tested,DeviceListener works,don't know others functions.
https://github.com/dotnet/csharplang/blob/master/proposals/csharp-7.3/improved-overload-candidates.md