### PR TITLE
Bugfix (GetHidString method)

### DIFF
--- a/src/Hid.Net/Windows/WindowsHidApiService.cs
+++ b/src/Hid.Net/Windows/WindowsHidApiService.cs
@@ -152,15 +152,14 @@ namespace Hid.Net.Windows
             {
                 var pointerToBuffer = Marshal.AllocHGlobal(126);
                 var isSuccess = getString(safeFileHandle, pointerToBuffer, 126);
-                Marshal.FreeHGlobal(pointerToBuffer);
-
                 if (!isSuccess)
                 {
                     logger?.Log($"Could not get Hid string. Caller: {callMemberName}", nameof(WindowsHidApiService), null, LogLevel.Warning);
                 }
+                var text = Marshal.PtrToStringAuto(pointerToBuffer);
 
-
-                return Marshal.PtrToStringUni(pointerToBuffer);
+                Marshal.FreeHGlobal(pointerToBuffer);
+                return text;
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
I recognized that the first character of some fields (manufacturer, product and serial number) was wrong decoded.  I think the FreeHGlobal call was a bit early.

This should be the solution.