### PR TITLE
Fixed a bug in DeviceListeners

### DIFF
--- a/src/Device.Net/Helpers.cs
+++ b/src/Device.Net/Helpers.cs
@@ -15,7 +15,7 @@ namespace Device.Net
         public static string GetHex(uint? id)
         {
             //TODO: Fix code rules here
-            return id?.ToString("X").ToLower().PadLeft(4, '0');
+            return id?.ToString("X").PadLeft(4, '0');
         }
 
         public static CultureInfo ParsingCulture { get; } = new CultureInfo("en-US");

--- a/src/Device.Net/Helpers.cs
+++ b/src/Device.Net/Helpers.cs
@@ -15,7 +15,7 @@ namespace Device.Net
         public static string GetHex(uint? id)
         {
             //TODO: Fix code rules here
-            return id?.ToString("X").PadLeft(4, '0');
+            return id?.ToString("X").ToLower().PadLeft(4, '0');
         }
 
         public static CultureInfo ParsingCulture { get; } = new CultureInfo("en-US");


### PR DESCRIPTION
When a DeviceListener was disposed, the polltimer still elapses if it isnt stopped before it elapses.
This causes a state where the semaphore is disposed, but the polltimer still runs

and therefore causes an ObjectDisposedException


