### PR TITLE
Remove unwanted call to CreateWindowsUsbDeviceFactory in STM DFU tests

### DIFF
--- a/src/Device.Net.UnitTests/IntegrationTests.cs
+++ b/src/Device.Net.UnitTests/IntegrationTests.cs
@@ -31,8 +31,7 @@ namespace Device.Net.UnitTests
         public async Task TestFindSTMDFUModeWithFactory()
         {
             var deviceFactory = new FilterDeviceDefinition(0x0483, 0xdf11)
-                .CreateWindowsUsbDeviceFactory()
-                .CreateWindowsUsbDeviceFactory(classGuid: WindowsDeviceConstants.GUID_DEVINTERFACE_USB_DEVICE);
+                .CreateWindowsUsbDeviceFactory();
 
             var devices = await deviceFactory.GetConnectedDeviceDefinitionsAsync();
 
@@ -43,7 +42,7 @@ namespace Device.Net.UnitTests
         public async Task TestFindSTMDFUModeWithFactory2()
         {
             var device = await new FilterDeviceDefinition(0x0483, 0xdf11)
-                .CreateWindowsUsbDeviceFactory(classGuid: WindowsDeviceConstants.GUID_DEVINTERFACE_USB_DEVICE)
+                .CreateWindowsUsbDeviceFactory()
                 .GetFirstDeviceAsync();
 
             await device.InitializeAsync();


### PR DESCRIPTION
- Only the filtered call should be there, otherwise also the WindowsDeviceConstants.GUID_DEVINTERFACE_USB_DEVICE devices will show up.