### PR TITLE
Fix WinUSB double free issue

### DIFF
--- a/src/Usb.Net/Windows/WinUsbApiCalls.cs
+++ b/src/Usb.Net/Windows/WinUsbApiCalls.cs
@@ -50,7 +50,7 @@ namespace Usb.Net.Windows
         public static extern bool WinUsb_Free(SafeFileHandle InterfaceHandle);
 
         [DllImport("winusb.dll", SetLastError = true)]
-        public static extern bool WinUsb_Initialize(SafeFileHandle DeviceHandle, out SafeFileHandle InterfaceHandle);
+        public static extern bool WinUsb_Initialize(SafeFileHandle DeviceHandle, out IntPtr InterfaceHandle);
 
         [DllImport("winusb.dll", SetLastError = true)]
         public static extern bool WinUsb_QueryDeviceInformation(IntPtr InterfaceHandle, uint InformationType, ref uint BufferLength, ref byte Buffer);

--- a/src/Usb.Net/Windows/WindowsUsbInterfaceManager.cs
+++ b/src/Usb.Net/Windows/WindowsUsbInterfaceManager.cs
@@ -73,12 +73,12 @@ namespace Usb.Net.Windows
 
                 Logger.LogInformation(Messages.SuccessMessageGotWriteAndReadHandle);
 
-#pragma warning disable CA2000 //We need to hold on to this handle
                 var isSuccess = WinUsbApiCalls.WinUsb_Initialize(_DeviceHandle, out var interfaceHandle);
-#pragma warning restore CA2000
                 _ = WindowsHelpers.HandleError(isSuccess, Messages.ErrorMessageCouldntIntializeDevice, Logger);
 
+#pragma warning disable CA2000 //We need to hold on to this handle
                 var defaultInterfaceHandle = new SafeFileHandle(interfaceHandle, false);
+#pragma warning restore CA2000
                 var connectedDeviceDefinition = GetDeviceDefinition(defaultInterfaceHandle, DeviceId, Logger);
 
                 if (!WriteBufferSizeProtected.HasValue)

--- a/src/Usb.Net/Windows/WindowsUsbInterfaceManager.cs
+++ b/src/Usb.Net/Windows/WindowsUsbInterfaceManager.cs
@@ -74,10 +74,11 @@ namespace Usb.Net.Windows
                 Logger.LogInformation(Messages.SuccessMessageGotWriteAndReadHandle);
 
 #pragma warning disable CA2000 //We need to hold on to this handle
-                var isSuccess = WinUsbApiCalls.WinUsb_Initialize(_DeviceHandle, out var defaultInterfaceHandle);
+                var isSuccess = WinUsbApiCalls.WinUsb_Initialize(_DeviceHandle, out var interfaceHandle);
 #pragma warning restore CA2000
                 _ = WindowsHelpers.HandleError(isSuccess, Messages.ErrorMessageCouldntIntializeDevice, Logger);
 
+                var defaultInterfaceHandle = new SafeFileHandle(interfaceHandle, false);
                 var connectedDeviceDefinition = GetDeviceDefinition(defaultInterfaceHandle, DeviceId, Logger);
 
                 if (!WriteBufferSizeProtected.HasValue)


### PR DESCRIPTION
This is an immediate fix to the double freeing issue with WinUSB, see #163.

Note that we should take a good look at whether we should be using `SafeFileHandle` in the future, since the handle from WinUSB is not actually a file handle and should be freed by WinUSB, not `CloseHandle()` from Windows API that `SafeFileHandle` uses.