### PR TITLE
Added factory builder.

### DIFF
--- a/src/Device.Net/FactoryBuilder.cs
+++ b/src/Device.Net/FactoryBuilder.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace Device.Net
+{
+    public class FactoryBuilder : IFactoryBuilder
+    {
+        public ILoggerFactory LoggerFactory { get; }
+        public ReadOnlyCollection<IDeviceFactory> Factories { get; }
+
+        public FactoryBuilder(ILoggerFactory loggerFactory = null) => LoggerFactory = loggerFactory;
+
+        public FactoryBuilder(IDeviceFactory deviceFactory, ILoggerFactory loggerFactory = null)
+            : this(loggerFactory)
+        {
+            if (deviceFactory != null)
+            {
+                Factories = new ReadOnlyCollection<IDeviceFactory>(new IDeviceFactory[] { deviceFactory });
+            }
+        }
+
+        public FactoryBuilder(IList<IDeviceFactory> deviceFactories, ILoggerFactory loggerFactory = null)
+            : this(loggerFactory)
+        {
+            if (deviceFactories != null)
+            {
+                Factories = new ReadOnlyCollection<IDeviceFactory>(deviceFactories);
+            }
+        }
+
+        public IDeviceFactory Build() => Factories.Aggregate();
+
+    }
+}

--- a/src/Device.Net/IFactoryBuilder.cs
+++ b/src/Device.Net/IFactoryBuilder.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.Extensions.Logging;
+using System.Collections.ObjectModel;
+
+namespace Device.Net
+{
+    public interface IFactoryBuilder
+    {
+        ILoggerFactory LoggerFactory { get; }
+        ReadOnlyCollection<IDeviceFactory> Factories { get; }
+        IDeviceFactory Build();
+    }
+}

--- a/src/Hid.Net/Windows/WindowsHidDeviceFactoryExtensions.cs
+++ b/src/Hid.Net/Windows/WindowsHidDeviceFactoryExtensions.cs
@@ -18,6 +18,78 @@ namespace Hid.Net.Windows
     {
         #region Public Methods
 
+        public static IFactoryBuilder CreateWindowsHidDeviceFactory(
+        this IFactoryBuilder builder,
+        FilterDeviceDefinition filterDeviceDefinition,
+        IHidApiService hidApiService = null,
+        Guid? classGuid = null,
+        ushort? readBufferSize = null,
+        ushort? writeBufferSize = null,
+        GetConnectedDeviceDefinitionsAsync getConnectedDeviceDefinitionsAsync = null,
+        Func<Report, TransferResult> readReportTransform = null,
+        Func<TransferResult, Report> readTransferTransform = null,
+        Func<byte[], byte, byte[]> writeTransferTransform = null,
+        WriteReportTransform writeReportTransform = null)
+        {
+            _ = builder ?? throw new ArgumentNullException(nameof(builder));
+
+            var factories = new List<IDeviceFactory>(builder.Factories)
+            {
+                CreateWindowsHidDeviceFactory
+                (
+                new ReadOnlyCollection<FilterDeviceDefinition>(new List<FilterDeviceDefinition> { filterDeviceDefinition }),
+                builder.LoggerFactory,
+                hidApiService,
+                classGuid,
+                readBufferSize,
+                writeBufferSize,
+                getConnectedDeviceDefinitionsAsync,
+                readReportTransform,
+                readTransferTransform,
+                writeTransferTransform,
+                writeReportTransform
+                )
+            };
+
+            return new FactoryBuilder(factories, builder.LoggerFactory);
+        }
+
+        public static IFactoryBuilder CreateWindowsHidDeviceFactory(
+        this IFactoryBuilder builder,
+        FilterDeviceDefinition[] filterDeviceDefinitions,
+        IHidApiService hidApiService = null,
+        Guid? classGuid = null,
+        ushort? readBufferSize = null,
+        ushort? writeBufferSize = null,
+        GetConnectedDeviceDefinitionsAsync getConnectedDeviceDefinitionsAsync = null,
+        Func<Report, TransferResult> readReportTransform = null,
+        Func<TransferResult, Report> readTransferTransform = null,
+        Func<byte[], byte, byte[]> writeTransferTransform = null,
+        WriteReportTransform writeReportTransform = null)
+        {
+            _ = builder ?? throw new ArgumentNullException(nameof(builder));
+
+            var factories = new List<IDeviceFactory>(builder.Factories)
+            {
+                CreateWindowsHidDeviceFactory
+                (
+                new ReadOnlyCollection<FilterDeviceDefinition>(filterDeviceDefinitions),
+                builder.LoggerFactory,
+                hidApiService,
+                classGuid,
+                readBufferSize,
+                writeBufferSize,
+                getConnectedDeviceDefinitionsAsync,
+                readReportTransform,
+                readTransferTransform,
+                writeTransferTransform,
+                writeReportTransform
+                )
+            };
+
+            return new FactoryBuilder(factories, builder.LoggerFactory);
+        }
+
         /// <summary>
         /// Creates a <see cref="IDeviceFactory"/> for Windows Hid devices
         /// </summary>


### PR DESCRIPTION
Hi,

These changes offer an alternative way of building factories. It tends to simplify the usage during the initialization/definition phase. Perhaps it's more intuitive? (that's a bit subjective). I tried not to introduce any breaking changes, so any existing code should work, the existing API remains as it is.

For now, it covers only `WindowsHidDeviceFactory`, and it's provided just as a sample. If this approach is preferred, then it can be extended to include the rest of the components. <strong>So, this PR is incomplete</strong>

Sample usage:

```c#
// Optional
var loggerFactory = LoggerFactory.Create((builder) =>
{
    _ = builder.AddDebug().SetMinimumLevel(LogLevel.Trace);
});

var factories = new FactoryBuilder(loggerFactory)
    .CreateWindowsHidDeviceFactory(new FilterDeviceDefinition)
    .CreateWindowsHidDeviceFactory(new FilterDeviceDefinition[]
    {
        new FilterDeviceDefinition(),
        new FilterDeviceDefinition(),
    })
    .Build();
```