### PR TITLE
Enable async I/O handles to support cancellation tokens

### DIFF
--- a/src/Device.Net/Windows/ApiService.cs
+++ b/src/Device.Net/Windows/ApiService.cs
@@ -14,6 +14,8 @@ namespace Device.Net.Windows
     internal class ApiService : IApiService
     {
         #region Fields
+        private const uint FILE_FLAG_OVERLAPPED = 0x40000000;
+
         protected ILogger Logger { get; }
         #endregion
 
@@ -38,7 +40,7 @@ namespace Device.Net.Windows
         private SafeFileHandle CreateConnection(string deviceId, FileAccessRights desiredAccess, uint shareMode, uint creationDisposition)
         {
             Logger.LogInformation("Calling {call} Area: {area} for DeviceId: {deviceId}. Desired Access: {desiredAccess}. Share mode: {shareMode}. Creation Disposition: {creationDisposition}", nameof(APICalls.CreateFile), nameof(ApiService), deviceId, desiredAccess, shareMode, creationDisposition);
-            return APICalls.CreateFile(deviceId, desiredAccess, shareMode, IntPtr.Zero, creationDisposition, 0, IntPtr.Zero);
+            return APICalls.CreateFile(deviceId, desiredAccess, shareMode, IntPtr.Zero, creationDisposition, FILE_FLAG_OVERLAPPED, IntPtr.Zero);
         }
         #endregion
 

--- a/src/Hid.Net/Windows/WindowsHidApiService.cs
+++ b/src/Hid.Net/Windows/WindowsHidApiService.cs
@@ -137,9 +137,9 @@ namespace Hid.Net.Windows
         //TODO: These are not opening as async. If we do, we get an error. This is probably why cancellation tokens don't work.
         //https://github.com/MelbourneDeveloper/Device.Net/issues/188
 
-        public Stream OpenRead(SafeFileHandle readSafeFileHandle, ushort readBufferSize) => new FileStream(readSafeFileHandle, FileAccess.Read, readBufferSize, false);
+        public Stream OpenRead(SafeFileHandle readSafeFileHandle, ushort readBufferSize) => new FileStream(readSafeFileHandle, FileAccess.Read, readBufferSize, true);
 
-        public Stream OpenWrite(SafeFileHandle writeSafeFileHandle, ushort writeBufferSize) => new FileStream(writeSafeFileHandle, FileAccess.ReadWrite, writeBufferSize, false);
+        public Stream OpenWrite(SafeFileHandle writeSafeFileHandle, ushort writeBufferSize) => new FileStream(writeSafeFileHandle, FileAccess.ReadWrite, writeBufferSize, true);
         #endregion
 
         #region Private Methods


### PR DESCRIPTION
Resolves #188 by opening handles in asynchronous (overlapped) mode.