### PR TITLE
Fix for Issue #199: System.ArgumentOutOfRangeException "Positive number required"

### DIFF
--- a/src/Device.Net.UnitTests/WindowsHidApiServiceTests.cs
+++ b/src/Device.Net.UnitTests/WindowsHidApiServiceTests.cs
@@ -1,0 +1,37 @@
+﻿using Device.Net.Windows;
+using Hid.Net.Windows;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Win32.SafeHandles;
+using System;
+using System.IO;
+
+namespace Device.Net.UnitTests
+{
+    [TestClass]
+    public class WindowsHidApiServiceTests
+    {
+        private SafeFileHandle CreateFileHandle()
+        {
+            return APICalls.CreateFile(Path.GetTempFileName(),
+                    FileAccessRights.GenericWrite | FileAccessRights.GenericRead,
+                    APICalls.FileShareRead | APICalls.FileShareWrite, IntPtr.Zero, APICalls.OpenExisting,
+                    APICalls.FileAttributeNormal | APICalls.FileFlagOverlapped, IntPtr.Zero);
+        }
+
+        [TestMethod]
+        public void OpenWriteDoesNotThrowWhenZeroLengthBuffer()
+        {
+            var windowsHidApiService = new WindowsHidApiService(null);
+            using var handle = CreateFileHandle();
+            _ = windowsHidApiService.OpenWrite(handle, 0);
+        }
+
+        [TestMethod]
+        public void OpenWriteDoesNotThrowWhenMoreThanZero()
+        {
+            var windowsHidApiService = new WindowsHidApiService(null);
+            using var handle = CreateFileHandle();
+            _ = windowsHidApiService.OpenWrite(handle, 10);
+        }
+    }
+}

--- a/src/Hid.Net/Windows/WindowsHidApiService.cs
+++ b/src/Hid.Net/Windows/WindowsHidApiService.cs
@@ -139,7 +139,7 @@ namespace Hid.Net.Windows
 
         public Stream OpenRead(SafeFileHandle readSafeFileHandle, ushort readBufferSize) => new FileStream(readSafeFileHandle, FileAccess.Read, readBufferSize, true);
 
-        public Stream OpenWrite(SafeFileHandle writeSafeFileHandle, ushort writeBufferSize) => new FileStream(writeSafeFileHandle, FileAccess.ReadWrite, writeBufferSize, true);
+        public Stream OpenWrite(SafeFileHandle writeSafeFileHandle, ushort writeBufferSize) => writeBufferSize > 0 ? new FileStream(writeSafeFileHandle, FileAccess.ReadWrite, writeBufferSize, true) : Stream.Null;
         #endregion
 
         #region Private Methods


### PR DESCRIPTION
Fixes issue #199 
If the device returns a write buffer length of zero, the FileStream is openned with a  `writeBufferSize` of zero which throws
> System.ArgumentOutOfRangeException "Positive number required"

This change will return `Stream.Null` in that scenario.