### PR TITLE
Added flag to disable changes from #215 for .Net Framework

### DIFF
--- a/src/Device.Net/Windows/ApiService.cs
+++ b/src/Device.Net/Windows/ApiService.cs
@@ -14,7 +14,11 @@ namespace Device.Net.Windows
     internal class ApiService : IApiService
     {
         #region Fields
+#if NETFRAMEWORK
+        private const uint FILE_FLAG_OVERLAPPED = 0;
+#else
         private const uint FILE_FLAG_OVERLAPPED = 0x40000000;
+#endif
 
         protected ILogger Logger { get; }
         #endregion

--- a/src/Hid.Net/Windows/WindowsHidApiService.cs
+++ b/src/Hid.Net/Windows/WindowsHidApiService.cs
@@ -137,9 +137,14 @@ namespace Hid.Net.Windows
         //TODO: These are not opening as async. If we do, we get an error. This is probably why cancellation tokens don't work.
         //https://github.com/MelbourneDeveloper/Device.Net/issues/188
 
-        public Stream OpenRead(SafeFileHandle readSafeFileHandle, ushort readBufferSize) => new FileStream(readSafeFileHandle, FileAccess.Read, readBufferSize, true);
+#if NETFRAMEWORK
+        private const bool _isAsync = false;
+#else
+        private const bool _isAsync = true;
+#endif
+        public Stream OpenRead(SafeFileHandle readSafeFileHandle, ushort readBufferSize) => new FileStream(readSafeFileHandle, FileAccess.Read, readBufferSize, _isAsync);
 
-        public Stream OpenWrite(SafeFileHandle writeSafeFileHandle, ushort writeBufferSize) => new FileStream(writeSafeFileHandle, FileAccess.ReadWrite, writeBufferSize, true);
+        public Stream OpenWrite(SafeFileHandle writeSafeFileHandle, ushort writeBufferSize) => new FileStream(writeSafeFileHandle, FileAccess.ReadWrite, writeBufferSize, _isAsync);
         #endregion
 
         #region Private Methods


### PR DESCRIPTION
Implemented #if switch to revert #215 in .Net framework applications to fix #222.

Changes to Hid.Net\Windows\WindowsHidApiService.cs, could be more elegant as the fix just override what `FILE_FLAG_OVERLAPPED` means.