### PR TITLE
Fix control requests with libusb

### DIFF
--- a/src/Device.Net.LibUsb/UsbInterface.cs
+++ b/src/Device.Net.LibUsb/UsbInterface.cs
@@ -98,7 +98,7 @@ namespace Device.Net.LibUsb
                 buffer ??= new byte[setupPacket.Length];
 
                 var sp = new UsbSetupPacket(
-                    (byte)setupPacket.RequestType.Type,
+                    setupPacket.RequestType.ToByte(),
                     setupPacket.Request,
                     setupPacket.Value,
                     setupPacket.Index,


### PR DESCRIPTION
Control requests were being made with just the type instead of the entire request type, hence libusb would create the wrong type of request.